### PR TITLE
Add sticky nav to extensions table

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,0 +1,38 @@
+function createStickyHeader(target) {
+  var stickyHeader = document.createElement('div');
+  var cloneRow = document.createElement('div');
+  var targetRect = target.getBoundingClientRect();
+  stickyHeader.classList.add('sticky-header');
+  stickyHeader.style.height = targetRect.height;
+  stickyHeader.appendChild(cloneRow);
+  cloneRow.classList.add('tr');
+  cloneRow.style.left = targetRect.left;
+  cloneRow.style.width = targetRect.width;
+  Array.prototype.forEach.call(target.children, function(th, i){
+    var fakeHeader = document.createElement('div');
+    var thRect = th.getBoundingClientRect();
+    fakeHeader.classList.add('th');
+    fakeHeader.innerHTML = th.innerHTML;
+    fakeHeader.style.cssText = document.defaultView.getComputedStyle(th, "").cssText;
+    fakeHeader.style.position = 'absolute';
+    fakeHeader.style.left = thRect.left - targetRect.left;
+    cloneRow.appendChild(fakeHeader);
+  });
+  document.body.appendChild(stickyHeader);
+  return stickyHeader;
+}
+
+var stickyTarget = document.querySelector('[data-sticky-header]');
+var stickyClone = createStickyHeader(stickyTarget);
+
+var stickyHeaderToggle = function() {
+  this.targetTop = this.targetTop || stickyTarget.getBoundingClientRect().top + document.body.scrollTop;
+  if(document.body.scrollTop >= this.targetTop) {
+    stickyClone.classList.remove('hide')
+  } else {
+    stickyClone.classList.add('hide')
+  }
+};
+
+window.addEventListener('scroll', stickyHeaderToggle);
+stickyHeaderToggle();

--- a/status.html.erb
+++ b/status.html.erb
@@ -24,7 +24,7 @@
 
     <table class="statuses">
       <thead>
-        <tr>
+        <tr data-sticky-header>
           <th></th>
           <th></th>
           <% VERSIONS.each do |version| %>
@@ -65,5 +65,7 @@
   <footer>
     Last updated <%= Time.now.utc.to_s %>
   </footer>
+
+  <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -99,3 +99,19 @@ footer {
   text-align: center;
   color: grey;
 }
+
+.sticky-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background: white;
+}
+
+.sticky-header .tr {
+  position: absolute;
+}
+
+.hide {
+  display: none;
+}


### PR DESCRIPTION
Okay, I admit that's it's just a ball of JS, but I thought as long as didn't pull in any libs you'd let it slide 😉 

<img width="1012" alt="screen shot 2016-06-04 at 1 50 34 pm" src="https://cloud.githubusercontent.com/assets/1529452/15802020/a2614666-2a5b-11e6-8218-e6be20c16a03.png">
