### PR TITLE
Add Elastic Product extension

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -41,6 +41,7 @@ PROJECTS = {
   'boomerdigital/solidus_email_to_friend'           => %w[master],
   'boomerdigital/solidus_user_roles'                => %w[master],
   'boomerdigital/solidus_amazon_payments'           => %w[master],
+  'boomerdigital/solidus_elastic_product'           => %w[master],
 }.map{|name, branches| SolidusExtensions::Project.new(name, branches) }
 
 task :retrigger do


### PR DESCRIPTION
I've come to create and support an extension to integrate with Elastic Search.


The [README](https://github.com/boomerdigital/solidus_elastic_product) contains extensive information on its purpose and usage.

I'd be happy to have the extension added to the officially supported list. Let me know if I missed something from the process.