### PR TITLE
Add solidus_tax_cloud

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,6 +40,7 @@ PROJECTS = {
   'solidusio-contrib/solidus_volume_pricing'        => %w[master],
   'solidusio-contrib/solidus_legacy_stock_system'   => %w[master],
   'solidusio-contrib/solidus_affirm'                => %w[master],
+  'solidusio-contrib/solidus_tax_cloud'             => %w[master],
 
   'boomerdigital/solidus_wishlist'                  => %w[master],
   'boomerdigital/solidus_email_to_friend'           => %w[master],


### PR DESCRIPTION
There has been a lot of recent activity on the `solidus_tax_cloud` gem, including getting a full set of passing specs (tricky because US sales tax rates can change every year!), and CI testing with Travis.

The `master` branch should be compatible across most recent versions of Solidus, and there are individual named branches (e.g., `v1.3`, `v2.1`, etc.) for older releases as well.