### PR TITLE
Add maintainer image to extensions

### DIFF
--- a/lib/circleci_solidus_extensions.rb
+++ b/lib/circleci_solidus_extensions.rb
@@ -19,6 +19,10 @@ module SolidusExtensions
         "https://github.com/#{org}/#{repo}"
       end
 
+      def org_image_url
+        "https://github.com/#{org}.png"
+      end
+
       def branches
         @branches.map do |name|
           Branch.new(self, name)
@@ -49,7 +53,10 @@ module SolidusExtensions
             <tr>
               <% if i == 0 %>
                 <th class="name" rowspan="<%= branches.size %>">
-                  <a href="<%= github_url %>"><%= repo %></a>
+                  <a class= "project-link" href="<%= github_url %>">
+                    <img src="<%= org_image_url %>" />
+                    <%= repo %>
+                  </a>
                 </th>
               <% end %>
               <td><%= branch.name %></td>

--- a/lib/solidus_extensions.rb
+++ b/lib/solidus_extensions.rb
@@ -70,6 +70,10 @@ module SolidusExtensions
       "https://github.com/#{fullname}"
     end
 
+    def org_image_url
+      "https://github.com/#{org}.png"
+    end
+
     def travis_url
       "https://travis-ci.org/#{fullname}"
     end
@@ -119,7 +123,10 @@ module SolidusExtensions
           <tr>
             <% if i == 0 %>
               <th class="name" rowspan="<%= branches.size %>">
-                <a href="<%= github_url %>"><%= repo %></a>
+                <a class= "project-link" href="<%= github_url %>">
+                  <img src="<%= org_image_url %>" />
+                  <%= repo %>
+                </a>
               </th>
             <% end %>
             <td><%= branch.name %></td>

--- a/style.css
+++ b/style.css
@@ -28,6 +28,13 @@ td, th {
 th.name {
   text-align: right;
 }
+.project-link {
+  white-space: nowrap;
+}
+.project-link img {
+  width: 15px;
+  vertical-align: middle;
+}
 .status {
   color: white;
   padding: 0;


### PR DESCRIPTION
Add a small logo on extensions to represent who is the maintainer:

<img width="687" alt="Schermata 2019-09-24 alle 15 38 00" src="https://user-images.githubusercontent.com/167946/65516461-56655480-dee1-11e9-8f4f-71753c44bef9.png">
