### PR TITLE
Redirect all accesses to solidus.io/extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+*Note: Moved to solidus.io/extensions*
+
+This website is no more relevant since all the information presented
+has been moved to [solidus.io/extensions](https://solidus.io/extensions).

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+/                   https://solidus.io/extensions/


### PR DESCRIPTION
This rule tells Netlify to redirect all visits to our main website, in the extensions page. This page has been updated to contain all the information already present here so we can safely dismiss this website.